### PR TITLE
Improving Support for Series With Unknown Number of Episodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "animelist-ext",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "build": "rm -rf dist && npx gulp release",
     "lint": "npx addons-linter dist",

--- a/src/components/EpisodeSelector.tsx
+++ b/src/components/EpisodeSelector.tsx
@@ -58,7 +58,9 @@ const EpisodeSelector = (props: EpisodeSelectorProps) => {
                 disabled={!props.enabled}
             />
             <div className="current-value" style={{ display: focused ? "none" : "block" }}>
-                <span className="value">{props.current}</span>/{props.totalEpisodes}
+                <span className="value">{props.current}</span>/{
+                    props.totalEpisodes == 0 ? "?" : props.totalEpisodes
+                }
             </div>
         </div>
         <button

--- a/src/components/EpisodeSelector.tsx
+++ b/src/components/EpisodeSelector.tsx
@@ -49,11 +49,9 @@ const EpisodeSelector = (props: EpisodeSelectorProps) => {
                 }}
                 onBlur={(event) => {
                     setFocused(false)
-                    const value = Math.min(current, props.totalEpisodes);
-                    if (props.current != value) {
-                        props.onChange(value);
+                    if (props.current != current) {
+                        props.onChange(current);
                     }
-                    setCurrent(value);
                 }}
                 onSubmit={() => fieldRef.current.blur()}
                 onFocus={() => setFocused(true)}
@@ -64,8 +62,10 @@ const EpisodeSelector = (props: EpisodeSelectorProps) => {
             </div>
         </div>
         <button
-            className={"inc-button" + (!!props.enabled && props.current < props.totalEpisodes ? " enabled" : "")}
-            disabled={!props.enabled || props.current >= props.totalEpisodes}
+            className={"inc-button" + (!!props.enabled && (
+                props.current < props.totalEpisodes || props.totalEpisodes == 0
+            ) ? " enabled" : "")}
+            disabled={!props.enabled || (props.current >= props.totalEpisodes && props.totalEpisodes != 0)}
             onClick={() => { props.onChange(props.current + 1) }} />
     </div>
 }

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -61,7 +61,11 @@ const Application = (props: ApplicationProps) => {
 
     const numWatchedChanged = (series: SeriesInfo, currentWatched: number, numberWatched: number) => {
         var suggested: AnimeStatus = null
-        if (state.currentList != "completed" && numberWatched == series.totalEpisodes) {
+        if (
+            state.currentList != "completed" &&
+            series.totalEpisodes != 0 &&
+            numberWatched == series.totalEpisodes
+        ) {
             suggested = "completed";
         } else if (state.currentList != "watching" && numberWatched > currentWatched) {
             suggested = "watching";


### PR DESCRIPTION
Changes in this PR:

1. The number of episodes watched is no longer bounded by the maximum number of episodes by the extension. The MAL API does not allow to exceed this number for series with known episodes count, even though it is possible through the web
2. The episodes with the unknown number of episodes are now labeled as `#/?` instead of `#/0`
3. Changed the logic for suggesting the status change: if the episodes number is unknown, the extension wont suggest marking series as completed

This PR should resolve #1.