### PR TITLE
Fixing a suggestions bug with completed episodes being completed

### DIFF
--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -69,19 +69,15 @@ const Application = (props: ApplicationProps) => {
     if (Object.keys(update).join() == "episodesWatched") {
       let suggested: AnimeStatus | null = null;
       if (
-        entry.status != AnimeStatus.Completed &&
         entry.series.totalEpisodes != 0 &&
         update.episodesWatched == entry.series.totalEpisodes
       ) {
         suggested = AnimeStatus.Completed;
-      } else if (
-        entry.status != AnimeStatus.Watching &&
-        update.episodesWatched > entry.episodesWatched
-      ) {
+      } else if (update.episodesWatched > entry.episodesWatched) {
         suggested = AnimeStatus.Watching;
       }
 
-      if (suggested) {
+      if (suggested && suggested != entry.status) {
         dispatch({
           type: "set-suggestion",
           listEntry: entry,


### PR DESCRIPTION
This PR fixes a bug: if a completed series is updated such as its number of watched episodes is increased to the total number of episodes, the extension erroneously suggests to mark it as "Watching"