### PR TITLE
Extended the security policy for image src

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -34,7 +34,7 @@
     "64": "./assets/icon-64.png",
     "128": "./assets/icon-128.png"
   },
-  "content_security_policy": "script-src 'self'; default-src https://myanimelist.net https://api.myanimelist.net; img-src https://api-cdn.myanimelist.net; object-src 'none'",
+  "content_security_policy": "script-src 'self'; default-src https://myanimelist.net https://api.myanimelist.net; img-src https://*.myanimelist.net; object-src 'none'",
   "permissions": [
     "storage",
     "identity",


### PR DESCRIPTION
This PR changes the content security policy: Images can now be loaded from any subdomain of `myanimelist.net` instead of only `api-cdn.myanimelist.net`. This is due to a recent change: the API changed the URL from which the images are served from `api-cdn.myanimelist.net` to `cdn.myanimelist.net`.